### PR TITLE
Fix encoding issue

### DIFF
--- a/Font_LDL/data.py
+++ b/Font_LDL/data.py
@@ -15,7 +15,7 @@ random.seed(config.random_random_seed)
 def read_text_embeddings(filename):
     embeddings = []
     word2index = {}
-    with open(filename, 'r') as f:
+    with open(filename, 'r', encoding='utf-8') as f:
         for i, line in enumerate(f):
             line = line.strip().split()
             word2index[line[0]] = i


### PR DESCRIPTION
The error was:
```
Running on CPU
[LOG] running . . . bert_seq_classification_V1
***********************printing status*************************
Train dataset: 916
Dev dataset: 131
Test dataset: 262
Train dataset words: ['We may encounter many defeats but we must not be defeated.', '• 1000+ high qualitypatterns • 9 new social sizes']
Train dataset labeles: [[0.195, 0.0, 0.12, 0.173, 0.068, 0.113, 0.045, 0.0, 0.14300000000000002, 0.14300000000000002], [0.075, 0.12, 0.241, 0.068, 0.045, 0.113, 0.14300000000000002, 0.12, 0.0, 0.075]]
Train dataset emojifeats: [array([-1.2710791e-02,  9.7703775e-03, -2.8587232e-05, ...,
       -9.4925361e-03, -1.9361263e-02,  5.0162524e-03], dtype=float32), array([ 0.00183615, -0.00894303,  0.        , ..., -0.03217574,
       -0.01422946,  0.03710809], dtype=float32)]
[LOG] num_of_unique_words:  3234
Traceback (most recent call last):
  File "main.py", line 41, in <module>
    encoder = Encoder.get_encoder(corpus, emb_path, encoder_pkl_path=encoder_pkl)
  File "/Font_LDL_2020/Font_LDL/data.py", line 73, in get_encoder
    encoder = Encoder(corpus, emb_path)
  File "/Font_LDL_2020/Font_LDL/data.py", line 31, in __init__
    self.word2index, self.word_emb = self.get_pretrain_embeddings(emb_path, corpus.get_word_vocab())
  File "/Font_LDL_2020/Font_LDL/data.py", line 96, in get_pretrain_embeddings
    w2i, emb = read_text_embeddings(filename)
  File "/Font_LDL_2020/Font_LDL/data.py", line 19, in read_text_embeddings
    for i, line in enumerate(f):
  File "/usr/lib/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 5454: ordinal not in range(128)
```